### PR TITLE
fix: ImportError: cannot import name 'url_quote' from 'werkzeug.urls' 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==2.0.1
 numpy==1.21.0
+Werkzeug>=2,<3


### PR DESCRIPTION
The project expects a version of Werkzeug that still includes url_quote. However, newer versions of Werkzeug have removed or relocated url_quote, causing the import error.

```
(venv) (venv) FVFFTSK3Q6L4:windsurf-demo gabriel.nes$ python3 app.py
Traceback (most recent call last):
  File "/Users/gabriel.nes/Documents/work/windsurf-demo/app.py", line 1, in <module>
    from flask import Flask, render_template, jsonify, request
  File "/Users/gabriel.nes/Documents/work/windsurf-demo/venv/lib/python3.9/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/Users/gabriel.nes/Documents/work/windsurf-demo/venv/lib/python3.9/site-packages/flask/app.py", line 28, in <module>
    from . import cli
  File "/Users/gabriel.nes/Documents/work/windsurf-demo/venv/lib/python3.9/site-packages/flask/cli.py", line 18, in <module>
    from .helpers import get_debug_flag
  File "/Users/gabriel.nes/Documents/work/windsurf-demo/venv/lib/python3.9/site-packages/flask/helpers.py", line 16, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/Users/gabriel.nes/Documents/work/windsurf-demo/venv/lib/python3.9/site-packages/werkzeug/urls.py)
```

To fix it, I pinned Werkzeug version >=2 (required by flask 2.0.1) but < 3.